### PR TITLE
Add parallel build script.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 build:
 	docker-compose build
+fast-build:
+	docker-compose build --parallel
 run:
 	docker-compose up
 lambda-terminal:


### PR DESCRIPTION
This allows for faster docker build times on multi-core machines.